### PR TITLE
Fixes #19 - Don't fail to load project if not in a git repo.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -85,7 +85,8 @@ object SbtGit extends Plugin {
       reader.withGit(_.currentTags)
     },
     gitCurrentBranch in ThisBuild <<= (gitReader in ThisBuild) apply { (reader) =>
-      reader.withGit(_.branch)
+      // TODO - Make current branch an option?
+      Option(reader.withGit(_.branch)) getOrElse ""
     }
   )
   override val settings = Seq(


### PR DESCRIPTION
Checks for null branch string and returns empty rather than
fail the build.

Fixes #19

Review by @hseeberger 
