### PR TITLE
Throw an exception when the forked git process fails.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ConsoleGitRunner.scala
@@ -20,7 +20,11 @@ object ConsoleGitRunner extends GitRunner {
     val full = cmd ++ args
     log.debug(cwd + "$ " + full.mkString(" "))
     val code = Process(full, cwd) ! gitLogger
-    gitLogger.flush(code)
+    val result = gitLogger.flush(code)
+    if(code != 0)
+      error("Nonzero exit code (" + code + ") running git.")
+    else
+      result
   }
 
   override def toString = "git"

--- a/src/main/scala/com/typesafe/sbt/git/JGitRunner.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGitRunner.scala
@@ -62,10 +62,11 @@ object JGitRunner extends GitRunner {
        case cl: java.net.URLClassLoader =>
          val cp = cl.getURLs map (_.getFile) mkString ":"
          val baos = new java.io.ByteArrayOutputStream
-         Fork.java(None, Seq("-classpath", cp, "org.eclipse.jgit.pgm.Main") ++ args, Some(cwd), CustomOutput(baos))
+			// NOTE: this will always return 0 until sbt 0.13.1 due to the use of CustomOutput
+         val code = Fork.java(None, Seq("-classpath", cp, "org.eclipse.jgit.pgm.Main") ++ args, Some(cwd), CustomOutput(baos))
          val result = baos.toString
          log.info(result)
-         result
+         if(code == 0) result else error("Nonzero exit code (" + code + ") running JGit.")
        case _ => sys.error("Could not find classpath for JGit!")
     }
 


### PR DESCRIPTION
This throws an exception when the exit code of the forked git process is nonzero.

There is a bug in Process where redirection-like methods like `#>` discard the exit code of the process.  This is because the methods are implemented on top of piping, which should discard the exit code of the input process.  This is fixed in the sbt 0.13 branch, but until 0.13.1, this means that the JGitRunner will not fail when the forked process fails.
