### PR TITLE
Update sbt and jgit version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "sbt-git"
 
 organization := "com.typesafe.sbt"
 
-version := "0.6.3"
+version := "0.6.4-SNAPSHOT"
 
-libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "2.2.0.201212191850-r"
+libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.3.0.201403021825-r"
 
 publishMavenStyle := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.2


### PR DESCRIPTION
This bumps sbt to use the latest 0.13.2, as well as bumps jgit to use the newer 3.3.0 version. Also bumped the version to 0.6.4-SNAPSHOT so it's ready to deploy. Context for this PR is I am using jgit directly in a project that needs APIs from v3, but I also want to use sbt-git APIs as well, which currently uses v2 of jgit. Would like to get this new version deployed if possible so I can rely on sbt-git directly.
