### PR TITLE
Git describe versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ You can alter the tag-detection algorithm using the `git.gitTagToVersionNumber` 
       else None
     }
 
+You can turn on version detection using `git describe` command by adding:
+
+    git.useGitDescribe := true
+
+This way version returned will be last tag + number of commits since tag + short hash.
 
 ## Prompts ##
 

--- a/src/main/scala/com/typesafe/sbt/git/JGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGit.scala
@@ -7,6 +7,8 @@ import java.io.File
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Ref
 
+import scala.util.Try
+
 
 // TODO - This class needs a bit more work, but at least it lets us use porcelain and wrap some higher-level
 // stuff on top of JGit, as needed for our plugin.
@@ -71,6 +73,10 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
       else
         peeled.getObjectId
     id.getName
+  }
+
+  override def describedVersion: Option[String] = {
+    Try { porcelain.describe().call() } toOption
   }
 }
 

--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -13,6 +13,8 @@ trait GitReadonlyInterface {
   def headCommitSha: Option[String]
   /** The current tags associated with the local repository (at its HEAD). */
   def currentTags: Seq[String]
+  /** Version of the software as returned by `git describe --tags`. */
+  def describedVersion: Option[String]
 }
 
 


### PR DESCRIPTION
Git has built in very nice way of versioning as described here: http://git-scm.com/docs/git-describe

This PR adds support to getting version from git describe command. It requires setting `git.useGitDescribe := true`, otherwise behaves as before.