### PR TITLE
Adding the missing dependency to dispatch 0.8.10

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "net.databinder" %% "dispatch-http" % "0.8.10"


### PR DESCRIPTION
To be able to compile the project since the addition of project/bintray.scala