### PR TITLE
Migrate to AutoPlugins in 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,20 @@ well as allowing other plugins to make use of git.
 
 ## Installation ##
 
+
+Latest:
+
+Add the following to your `project/plugins.sbt` or `~/.sbt/0.13/plugins/plugins.sbt` file:
+
+   addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.0")
+
+Prior to sbt 0.13.5:
+
 Add the following to your `project/plugins.sbt` or `~/.sbt/0.13/plugins/plugins.sbt` file:
 
     addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.7.1")
 
+additionally, use one of the older README.md files: (https://github.com/sbt/sbt-git/blob/v0.7.1/README.md)
 
 ### Using JGit ###
 
@@ -34,15 +44,9 @@ git activities.
 
 ## Versioning with Git ##
 
-You can begin to use git to control your project versions.  To do so, simply add the
-following settings to your build (not necessary for every project), in **this specific order**:
+You can begin to use git to control your project versions.
 
-    import com.typesafe.sbt.SbtGit._
-
-    versionWithGit
-
-    // Optionally:
-    git.baseVersion := "0.1"
+    enablePlugins(GitVersioning)
 
 The git plugin will now autogenerate your version using the following rules, in order:
 
@@ -64,13 +68,14 @@ You can turn on version detection using `git describe` command by adding:
 
     git.useGitDescribe := true
 
-This way version returned will be last tag + number of commits since tag + short hash.
+This way version returned will be last tag + number of commits since tag + short hash.  We recommend adopting the git describe approach.
+
 
 ## Prompts ##
 
 You can use the git plugin to add the project name + the current branch to your prompt. Simply add this setting to every project:
 
-    showCurrentGitBranch
+    enablePlugins(GitBranchPrompt)
 
 ## Usage ##
 

--- a/src/sbt-test/git-versioning/find-environment-variable/build.sbt
+++ b/src/sbt-test/git-versioning/find-environment-variable/build.sbt
@@ -1,6 +1,4 @@
-import com.typesafe.sbt.SbtGit._
-
-versionWithGit
+enablePlugins(GitVersioning)
 
 val checkVersion = taskKey[Unit]("checks the version is the tag versino")
 checkVersion := {

--- a/src/sbt-test/git-versioning/find-tag-newest/changes/build.sbt
+++ b/src/sbt-test/git-versioning/find-tag-newest/changes/build.sbt
@@ -1,7 +1,6 @@
-import com.typesafe.sbt.SbtGit._
 import complete.DefaultParsers._
 
-versionWithGit
+enablePlugins(GitVersioning)
 
 git.baseVersion := "0.1"
 git.versionProperty := "DUMMY_BUILD_VERSION"

--- a/src/sbt-test/git-versioning/find-tag/changes/build.sbt
+++ b/src/sbt-test/git-versioning/find-tag/changes/build.sbt
@@ -1,6 +1,4 @@
-import com.typesafe.sbt.SbtGit._
-
-versionWithGit
+enablePlugins(GitVersioning)
 
 git.baseVersion := "0.1"
 git.versionProperty := "DUMMY_BUILD_VERSION"
@@ -9,7 +7,7 @@ val checkVersion = taskKey[Unit]("checks the version is the tag versino")
 checkVersion := {
   val v = version.value
   val v2 = (version in ThisBuild).value
-  val tags = GitKeys.gitCurrentTags.value
+  val tags = git.gitCurrentTags.value
   assert(tags == Seq("v1.0.0"), s"Failed to discover git tag, tags: $tags")
   assert(v2 == "1.0.0", s"Failed to detect git tag, found ${v}")
   assert(v == "1.0.0", s"Version from ThisBuild not used, found ${v}")

--- a/src/sbt-test/git-versioning/no-base-version/changes/build.sbt
+++ b/src/sbt-test/git-versioning/no-base-version/changes/build.sbt
@@ -1,6 +1,4 @@
-import com.typesafe.sbt.SbtGit._
-
-versionWithGit
+enablePlugins(GitVersioning)
 
 git.versionProperty := "DUMMY_BUILD_VERSION"
 

--- a/src/sbt-test/git-versioning/uncommitted-signifier/changes/build.sbt
+++ b/src/sbt-test/git-versioning/uncommitted-signifier/changes/build.sbt
@@ -1,0 +1,12 @@
+enablePlugins(GitVersioning)
+
+git.baseVersion := "1.0"
+git.versionProperty := "DUMMY_BUILD_VERSION"
+
+val checkVersion = taskKey[Unit]("checks the version is the tag versino")
+checkVersion := {
+  val v = version.value
+  assert(v startsWith "1.0", s"git.baseVersion is meant to be optional ${v}")
+  assert(git.gitUncommittedChanges.value, s"SHould detect uncommitted git changes.")
+  assert(v endsWith "-SNAPSHOT", s"Should have -SNAPSHOT appended when uncommitted changes. ${v}")
+}

--- a/src/sbt-test/git-versioning/uncommitted-signifier/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/uncommitted-signifier/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/uncommitted-signifier/test
+++ b/src/sbt-test/git-versioning/uncommitted-signifier/test
@@ -1,0 +1,9 @@
+> git init
+> git config user.email "test@jsuereth.com"
+> git config user.name "Tester"
+> git add README.md
+> git commit -m "test"
+$ copy-file changes/build.sbt build.sbt
+> git add build.sbt
+> reload
+> checkVersion

--- a/src/sbt-test/git-versioning/use-describe/changes/build.sbt
+++ b/src/sbt-test/git-versioning/use-describe/changes/build.sbt
@@ -1,6 +1,4 @@
-import com.typesafe.sbt.SbtGit._
-
-versionWithGit
+enablePlugins(GitVersioning)
 
 git.baseVersion := "0.1"
 git.versionProperty := "DUMMY_BUILD_VERSION"

--- a/src/sbt-test/git-versioning/with-base-version/changes/build.sbt
+++ b/src/sbt-test/git-versioning/with-base-version/changes/build.sbt
@@ -1,6 +1,5 @@
-import com.typesafe.sbt.SbtGit._
+enablePlugins(GitVersioning)
 
-versionWithGit
 git.baseVersion := "1.0"
 git.versionProperty := "DUMMY_BUILD_VERSION"
 


### PR DESCRIPTION
Review by @eed3si9n.

The idea here is any dependent plugin (like ghpages) can still find the keys in the current path, thus remaining half-ass binary compatible.  I do plan to do a ghpages release shortly after 0.8 is out.