### PR TITLE
Removing unnecessary println since we already pass a logger to GitRunner

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -40,8 +40,6 @@ object SbtGit extends Plugin {
       val (state2, runner) = extracted.runTask(GitKeys.gitRunner, state)
       val dir = extracted.get(baseDirectory)
       val result = runner(args:_*)(dir, state2.log)
-      // TODO - Best way to print to console?
-      println(result)
       state2
     }
 


### PR DESCRIPTION
Now we get a single output prefixed with sbt log level, thus fixing issue #34. For example:
```
> git status
[info] On branch master
[info] Untracked files:
[info]   (use "git add <file>..." to include in what will be committed)
[info]
[info] 	project/project/
[info] 	project/target/
[info] 	target/
[info]
[info] nothing added to commit but untracked files present (use "git add" to track)
```

or 
```
> git log --oneline
[info] 2dc5048 Commiting it
[info] b517834 Commenting that line
[info] fb6e1df Initial commit
```
