### PR TITLE
Adding an additional signifier if there are uncommitted changes

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/JGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGit.scala
@@ -78,6 +78,9 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
   override def describedVersion: Option[String] = {
     Try { porcelain.describe().call() } toOption
   }
+  
+  override def hasUncommittedChanges: Boolean = porcelain.status.call.hasUncommittedChanges
+  
 }
 
 object JGit {

--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -15,6 +15,8 @@ trait GitReadonlyInterface {
   def currentTags: Seq[String]
   /** Version of the software as returned by `git describe --tags`. */
   def describedVersion: Option[String]
+  /** Whether there are uncommitted changes (i.e. whether any tracked file has changed) */
+  def hasUncommittedChanges: Boolean 
 }
 
 


### PR DESCRIPTION
Detects uncommitted changes and appends a signifier at the end of the version.

for example:
```
> show version
[info] 58308ce755ede57f19e78acb24bbab1c1ecfc691-SNAPSHOT
```

It exposes another key associated with version number, that defaults to Some("SNAPSHOT"):
```
val uncommittedSignifier = SettingKey[Option[String]]("uncommitted-signifier", "Optional additional signifier to signify uncommitted changes")
```

The actual signifier is optional and can be overridden:
```
> set git.uncommittedSignifier := Some("UNCOMMITTED")
> show version
[info] 58308ce755ede57f19e78acb24bbab1c1ecfc691-UNCOMMITTED
```

or even left empty:
```
> set git.uncommittedSignifier := None
> show version
[info] 58308ce755ede57f19e78acb24bbab1c1ecfc691
```

It uses JGit's status command to detect uncommitted changes which means that both changed tracked files and staged files will be detected as uncommitted changes.

It exposes an additional read-only setting key:
```
val gitUncommittedChanges = SettingKey[Boolean]("git-uncommitted-changes", "Whether there are uncommitted changes.")
```

I am not sure whether it should be appended to releaseVersion and describedVersion, so for now it's not.

for issue #32