### PR TITLE
Adding auto-completion of branch names to all git commands.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -40,6 +40,9 @@ object SbtGit extends AutoPlugin {
   }
 
   object GitCommand {
+    import complete._
+    import complete.DefaultParsers._
+    
     val action: (State, Seq[String]) => State = { (state, args) =>
       val extracted = Project.extract(state)
       import extracted._
@@ -48,10 +51,27 @@ object SbtGit extends AutoPlugin {
       val result = runner(args:_*)(dir, state2.log)
       state2
     }
-
-    // <arg> is the suggestion printed for tab completion on an argument
-    val command: Command = Command.args("git", "<args>")(action)
-
+    
+    // the git command we expose to the user
+    val command: Command = Command("git")(s =>  fullCommand(s)){ (state, arg) =>
+      val (command, args) = arg
+      action(state, command +: args)
+    }
+    
+    // the parser providing auto-completion for git command
+    def fullCommand(state: State) = {
+      val extracted = Project.extract(state)
+      import extracted._
+      val reader = extracted.get(GitKeys.gitReader)
+      implicit val branches: Seq[String] = reader.withGit(_.branches) ++ reader.withGit(_.remoteBranches) :+ "HEAD"
+      // let's not forget the user can define its own git commands and aliases so we don't want to parse the command
+      // TODO we could though provide a list of available git commands
+      // TODO some git commands like add take filepaths as arguments
+      token(Space) ~> token(NotQuoted, "<command>") ~ (Space ~> token(branch)).*
+    }
+    
+    def branch(implicit branches: Seq[String]): Parser[String] = NotQuoted.examples(branches.toSet)
+    
     private def isGitRepo(dir: File): Boolean = {
       if (System.getenv("GIT_DIR") != null) true
       else isGitDir(dir)

--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -17,6 +17,10 @@ trait GitReadonlyInterface {
   def describedVersion: Option[String]
   /** Whether there are uncommitted changes (i.e. whether any tracked file has changed) */
   def hasUncommittedChanges: Boolean 
+  /** The local branches */
+  def branches : Seq[String]
+  /** The remote branches */
+  def remoteBranches: Seq[String]
 }
 
 


### PR DESCRIPTION
First intent at adding auto completion to git commands (issue #47)

We're not actually parsing and checking the command for validity, just providing suggestions and auto-completion for branch names.

Also, we're not suggesting git commands for now. I wanted to avoid hard-coding all git commands. Perhaps we could run `git help -a` to get the list of all commands (but that does not work for JGit).

Concretely, git [TAB] simply shows <command>
```
> git 
<command>
```

After that, we show both local and remote branch names after *any and every* git command. That's obviously not perfect as there are command like `git add` that don't take branch names as argument.

Finally, we show the branch names after every argument, no matter how many (that's the behavior of [git-completion.bash](https://github.com/git/git/blob/master/contrib/completion/git-completion.bash) on my machine at least) , e.g:
```
> git checkout 
HEAD                                    branch-test1                            branch-test2                            master
origin/baseVersion-optional-candidate   origin/dispatch-dependency              origin/double-output                    origin/find-git-dir
origin/master                           origin/scala-build                      origin/scala-build-0.12.0-M2            origin/tab-completion
origin/uncommitted-changes              origin/wip/bintray-publishing           tab-completion
```

```
> git checkout master 
HEAD                                    branch-test1                            branch-test2                            master
origin/baseVersion-optional-candidate   origin/dispatch-dependency              origin/double-output                    origin/find-git-dir
origin/master                           origin/scala-build                      origin/scala-build-0.12.0-M2            origin/tab-completion
origin/uncommitted-changes              origin/wip/bintray-publishing           tab-completion
```

Feedback is welcome.

