### PR TITLE
Enabling color output from git commands

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ConsoleGitRunner.scala
@@ -14,12 +14,15 @@ object ConsoleGitRunner extends GitRunner {
 	}
   private lazy val cmd = if(isWindowsShell) Seq("cmd", "/c", "git") else Seq("git")
 
+  // in order to enable colors we trick git into thinking we're a pager, because it already knows we're not a tty
+  val colorSupport = ("GIT_PAGER_IN_USE", "1")
+  
   override def apply(args: String*)(cwd: File, log: Logger = ConsoleLogger()): String = {
     val gitLogger = new GitLogger(log)
     IO.createDirectory(cwd)
     val full = cmd ++ args
     log.debug(cwd + "$ " + full.mkString(" "))
-    val code = Process(full, cwd) ! gitLogger
+    val code = Process(full, cwd, colorSupport) ! gitLogger
     val result = gitLogger.flush(code)
     if(code != 0)
       error("Nonzero exit code (" + code + ") running git.")


### PR DESCRIPTION
To enable colored output from git, we trick it into thinking we're a pager by setting the environment variable `GIT_PAGER_IN_USE`

I have tried this only on mac os x with iTerm.

for issue #21 