### PR TITLE
isSnapshot should automatically set by the presence/absence of a git tag...

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -159,6 +159,9 @@ object SbtGit {
           val base = git.baseVersion.?.value
           git.defaultFormatDateVersion(base, new java.util.Date)
         },
+        isSnapshot in ThisBuild := {
+          git.gitCurrentTags.value.isEmpty
+        },
         version in ThisBuild := {
           val base = git.baseVersion.?.value
           val overrideVersion =

--- a/src/sbt-test/git-versioning/find-tag/changes/build.sbt
+++ b/src/sbt-test/git-versioning/find-tag/changes/build.sbt
@@ -11,4 +11,5 @@ checkVersion := {
   assert(tags == Seq("v1.0.0"), s"Failed to discover git tag, tags: $tags")
   assert(v2 == "1.0.0", s"Failed to detect git tag, found ${v}")
   assert(v == "1.0.0", s"Version from ThisBuild not used, found ${v}")
+  assert(isSnapshot.value == false, "For tagged git repos, snapshot should not be true.")
 }

--- a/src/sbt-test/git-versioning/uncommitted-signifier/changes/build.sbt
+++ b/src/sbt-test/git-versioning/uncommitted-signifier/changes/build.sbt
@@ -9,4 +9,5 @@ checkVersion := {
   assert(v startsWith "1.0", s"git.baseVersion is meant to be optional ${v}")
   assert(git.gitUncommittedChanges.value, s"SHould detect uncommitted git changes.")
   assert(v endsWith "-SNAPSHOT", s"Should have -SNAPSHOT appended when uncommitted changes. ${v}")
+  assert(isSnapshot.value == true, "-SNAPSHOT versions should have isSnapshot true.")
 }

--- a/src/sbt-test/git-versioning/with-base-version/changes/build.sbt
+++ b/src/sbt-test/git-versioning/with-base-version/changes/build.sbt
@@ -3,8 +3,9 @@ enablePlugins(GitVersioning)
 git.baseVersion := "1.0"
 git.versionProperty := "DUMMY_BUILD_VERSION"
 
-val checkVersion = taskKey[Unit]("checks the version is the tag versino")
+val checkVersion = taskKey[Unit]("checks the version is the correct versino")
 checkVersion := {
   val v = version.value
   assert(v startsWith "1.0", s"git.baseVersion is meant to be optional ${v}")
+  assert(isSnapshot.value == true, "isSnapshot should be true if not on a tag.")
 }


### PR DESCRIPTION
... when using git versioning.

Fixes #79.


Review by @eed3si9n  cc> @jroper