### PR TITLE
Avoid JGit throwing ConcurrentModificationException

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/JGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGit.scala
@@ -13,8 +13,11 @@ import scala.util.Try
 // TODO - This class needs a bit more work, but at least it lets us use porcelain and wrap some higher-level
 // stuff on top of JGit, as needed for our plugin.
 final class JGit(val repo: Repository) extends GitReadonlyInterface {
+  
+  // forcing initialization of shallow commits to avoid concurrent modification issue. See issue #85
+  repo.getObjectDatabase.newReader.getShallowCommits()
+  
   val porcelain = new PGit(repo)
-
 
   def create(): Unit = repo.create()
 


### PR DESCRIPTION
Using a brand new instance of JGit for every access should get rid of the ConcurrentModificationException, at the -obvious- cost of creating a new instance of JGit every time, including when fetching the completion options for the git command.

I believe the exceptions are due to thread-unsafe initialisation in JGit combined with sbt trying to initialise independent settings in parallel (the second part is really just a guess).

for issue #85 