### PR TITLE
No more dumping of the stack when the git command fails.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ConsoleGitRunner.scala
@@ -27,7 +27,7 @@ object ConsoleGitRunner extends GitRunner {
     val code = Process(full, cwd, colorSupport :_*) ! gitLogger
     val result = gitLogger.flush(code)
     if(code != 0)
-      error("Nonzero exit code (" + code + ") running git.")
+      throw new MessageOnlyException("Nonzero exit code (" + code + ") running git.")
     else
       result
   }

--- a/src/main/scala/com/typesafe/sbt/git/JGitRunner.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGitRunner.scala
@@ -66,11 +66,10 @@ object JGitRunner extends GitRunner {
          val code = Fork.java(None, Seq("-classpath", cp, "org.eclipse.jgit.pgm.Main") ++ args, Some(cwd), CustomOutput(baos))
          val result = baos.toString
          log.info(result)
-         if(code == 0) result else error("Nonzero exit code (" + code + ") running JGit.")
+         if(code == 0) result else throw new MessageOnlyException("Nonzero exit code (" + code + ") running JGit.")
        case _ => sys.error("Could not find classpath for JGit!")
     }
 
   override def toString = "jgit"
 
 }
-


### PR DESCRIPTION
for #101 as suggested by @pfn

Concretely a simple mistake like this: 

```
> git tatus
[error] git: 'tatus' is not a git command. See 'git --help'.
[error]
[error] Did you mean this?
[error]     status
java.lang.RuntimeException: Nonzero exit code (1) running git.
    at scala.sys.package$.error(package.scala:27)
    at scala.Predef$.error(Predef.scala:142)
    at com.typesafe.sbt.git.ConsoleGitRunner$.apply(ConsoleGitRunner.scala:30)
    at com.typesafe.sbt.SbtGit$GitCommand$$anonfun$1.apply(SbtGit.scala:49)
    at com.typesafe.sbt.SbtGit$GitCommand$$anonfun$1.apply(SbtGit.scala:45)
    at com.typesafe.sbt.SbtGit$GitCommand$$anonfun$3.apply(SbtGit.scala:56)
    at com.typesafe.sbt.SbtGit$GitCommand$$anonfun$3.apply(SbtGit.scala:54)
    at sbt.Command$$anonfun$applyEffect$1$$anonfun$apply$2.apply(Command.scala:59)
    at sbt.Command$$anonfun$applyEffect$1$$anonfun$apply$2.apply(Command.scala:59)
    at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
    at sbt.Command$$anonfun$applyEffect$2$$anonfun$apply$3.apply(Command.scala:61)
    at sbt.Command$.process(Command.scala:93)
    at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:98)
    at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:98)
    at sbt.State$$anon$1.process(State.scala:184)
    at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:98)
    at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:98)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.MainLoop$.next(MainLoop.scala:98)
    at sbt.MainLoop$.run(MainLoop.scala:91)
    at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:70)
    at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:65)
    at sbt.Using.apply(Using.scala:24)
    at sbt.MainLoop$.runWithNewLog(MainLoop.scala:65)
    at sbt.MainLoop$.runAndClearLast(MainLoop.scala:48)
    at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:32)
    at sbt.MainLoop$.runLogged(MainLoop.scala:24)
    at sbt.StandardMain$.runManaged(Main.scala:53)
    at sbt.xMain.run(Main.scala:28)
    at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
    at xsbt.boot.Launch$.withContextLoader(Launch.scala:129)
    at xsbt.boot.Launch$.run(Launch.scala:109)
    at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:36)
    at xsbt.boot.Launch$.launch(Launch.scala:117)
    at xsbt.boot.Launch$.apply(Launch.scala:19)
    at xsbt.boot.Boot$.runImpl(Boot.scala:44)
    at xsbt.boot.Boot$.main(Boot.scala:20)
    at xsbt.boot.Boot.main(Boot.scala)
[error] Nonzero exit code (1) running git.
[error] Use 'last' for the full log.
```

becomes:

```
> git tatus
[error] git: 'tatus' is not a git command. See 'git --help'.
[error]
[error] Did you mean this?
[error]     status
[error] Nonzero exit code (1) running git.
```
