### PR TITLE
Suppressing slf4j warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,10 @@ enablePlugins(GitVersioning)
 git.baseVersion := "0.8"
 
 
-libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r"
+libraryDependencies ++= Seq(
+  "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r",
+  "org.slf4j" % "slf4j-nop" % "1.7.13" // explicitly forcing the NO-OP binder to avoid warnings to be printed
+)
 
 publishMavenStyle := false
 


### PR DESCRIPTION
for #102 

This should suppress the warnings for users of the plugin. 

I believe developers running sbt on sbt-git directly will still see a warning which would be removed as well by adding the same dependency to plugins.sbt (or even a concrete one, not a no-op one) but I didn't go that far.
