### PR TITLE
Add headCommitMessage so we can get the commit message & do stuff bas…

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -15,6 +15,7 @@ object SbtGit {
     val gitCurrentBranch = SettingKey[String]("git-current-branch", "The current branch for this project.")
     val gitCurrentTags = SettingKey[Seq[String]]("git-current-tags", "The tags associated with this commit.")
     val gitHeadCommit = SettingKey[Option[String]]("git-head-commit", "The commit sha for the top commit of this project.")
+    val gitHeadMessage = SettingKey[Option[String]]("git-head-message", "The message for the top commit of this project.")
     val gitDescribedVersion = SettingKey[Option[String]]("git-described-version", "Version as returned by `git describe --tags`.")
     val gitUncommittedChanges = SettingKey[Boolean]("git-uncommitted-changes", "Whether there are uncommitted changes.")
     
@@ -109,6 +110,7 @@ object SbtGit {
     gitReader := new DefaultReadableGit(baseDirectory.value),
     gitRunner := ConsoleGitRunner,
     gitHeadCommit := gitReader.value.withGit(_.headCommitSha),
+    gitHeadMessage := gitReader.value.withGit(_.headCommitMessage),
     gitTagToVersionNumber := git.defaultTagByVersionStrategy,
     gitDescribedVersion := gitReader.value.withGit(_.describedVersion).map(v => git.gitTagToVersionNumber.value(v).getOrElse(v)),
     gitCurrentTags := gitReader.value.withGit(_.currentTags),
@@ -184,6 +186,7 @@ object SbtGit {
     val branch = GitKeys.gitBranch
     val runner = GitKeys.gitRunner in ThisBuild
     val gitHeadCommit = GitKeys.gitHeadCommit in ThisBuild
+    val gitHeadMessage = GitKeys.gitHeadMessage in ThisBuild
     val useGitDescribe = GitKeys.useGitDescribe in ThisBuild
     val gitDescribedVersion = GitKeys.gitDescribedVersion in ThisBuild
     val gitCurrentTags = GitKeys.gitCurrentTags in ThisBuild

--- a/src/main/scala/com/typesafe/sbt/git/JGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGit.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 // TODO - This class needs a bit more work, but at least it lets us use porcelain and wrap some higher-level
 // stuff on top of JGit, as needed for our plugin.
 final class JGit(val repo: Repository) extends GitReadonlyInterface {
-  
+
   // forcing initialization of shallow commits to avoid concurrent modification issue. See issue #85
   //repo.getObjectDatabase.newReader.getShallowCommits()
   // Instead we've thrown a lock around sbt's usage of this class.
@@ -82,7 +82,7 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
   override def describedVersion: Option[String] = Try(Option(porcelain.describe().call())).getOrElse(None)
 
   override def hasUncommittedChanges: Boolean = porcelain.status.call.hasUncommittedChanges
-  
+
   override def branches: Seq[String] = branchesRef.filter(_.getName.startsWith("refs/heads")).map(_.getName.drop(11))
 
   override def remoteBranches: Seq[String] = {
@@ -91,6 +91,7 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
     porcelain.branchList.setListMode(ListMode.REMOTE).call.asScala.filter(_.getName.startsWith("refs/remotes")).map(_.getName.drop(13))
   }
 
+  override def headCommitMessage: Option[String] = Try(Option(porcelain.log().setMaxCount(1).call().iterator().next().getFullMessage)).toOption.flatten
 }
 
 object JGit {

--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -21,6 +21,8 @@ trait GitReadonlyInterface {
   def branches : Seq[String]
   /** The remote branches */
   def remoteBranches: Seq[String]
+  /** The message of current commit **/
+  def headCommitMessage: Option[String]
 }
 
 

--- a/src/sbt-test/git-versioning/get-message/changes/build.sbt
+++ b/src/sbt-test/git-versioning/get-message/changes/build.sbt
@@ -1,0 +1,15 @@
+enablePlugins(GitVersioning)
+
+val expectNoMessage = taskKey[Unit]("checks that the commit message is empty")
+expectNoMessage := {
+  val headMessage = git.gitHeadMessage.value
+  assert(headMessage.isEmpty, s"Expected head message to be empty, found ${headMessage}")
+}
+
+val expectedMessage = "test message\n" // git appears to add a newline for commit messages
+val expectAMessage = taskKey[Unit]("checks that the commit message is equal to a predefined string")
+expectAMessage := {
+  val headMessage = git.gitHeadMessage.value
+  assert(headMessage.get == expectedMessage, s"Expected head message to equal '${expectedMessage}', found ${headMessage}")
+}
+

--- a/src/sbt-test/git-versioning/get-message/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/get-message/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/get-message/test
+++ b/src/sbt-test/git-versioning/get-message/test
@@ -1,0 +1,10 @@
+> git init
+> git config user.email "test@jsuereth.com"
+> git config user.name "Tester"
+> git add README.md
+$ copy-file changes/build.sbt build.sbt
+> reload
+> expectNoMessage
+> git commit -m "test message"
+> reload
+> expectAMessage


### PR DESCRIPTION
…ed on it.

Use cases based on captured contents of the commit message such as tags/hashtags:
* Conditional behaviours in the build
* Conditional behaviours in the application (e.g. one off task or migration)

https://github.com/sbt/sbt-git/pull/112#issuecomment-257247931