### PR TITLE
Add headCommitDate

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -15,9 +15,10 @@ object SbtGit {
     val gitCurrentBranch = SettingKey[String]("git-current-branch", "The current branch for this project.")
     val gitCurrentTags = SettingKey[Seq[String]]("git-current-tags", "The tags associated with this commit.")
     val gitHeadCommit = SettingKey[Option[String]]("git-head-commit", "The commit sha for the top commit of this project.")
+    val gitHeadCommitDate = SettingKey[Option[String]]("git-head-commit-date", "The commit date for the top commit of this project in ISO-8601 format.")
     val gitDescribedVersion = SettingKey[Option[String]]("git-described-version", "Version as returned by `git describe --tags`.")
     val gitUncommittedChanges = SettingKey[Boolean]("git-uncommitted-changes", "Whether there are uncommitted changes.")
-    
+
     // A Mechanism to run Git directly.
     val gitRunner = TaskKey[GitRunner]("git-runner", "The mechanism used to run git in the current build.")
 
@@ -33,7 +34,7 @@ object SbtGit {
     val baseVersion = SettingKey[String]("base-version", "The base version number which we will append the git version to.")
     val versionProperty = SettingKey[String]("version-property", "The system property that can be used to override the version number.  Defaults to `project.version`.")
     val uncommittedSignifier = SettingKey[Option[String]]("uncommitted-signifier", "Optional additional signifier to signify uncommitted changes")
-    
+
     // The remote repository we're using.
     val gitRemoteRepo = SettingKey[String]("git-remote-repo", "The remote git repository associated with this project")
   }
@@ -57,7 +58,7 @@ object SbtGit {
     }
 
     val QuotedString: Parser[String] = DQuoteClass ~> any.+.string.filter(!_.contains(DQuoteClass), _ => "Invalid quoted string") <~ DQuoteClass
-    
+
     // the parser providing auto-completion for git command
     // Note: This isn't an exact parser for git, it just tries to make it more convenient in sbt with a modicum of autocomplete.
     // Ideally we'd use the bash autocompletion scripts or zsh ones for full and complete information, but this actually
@@ -109,6 +110,7 @@ object SbtGit {
     gitReader := new DefaultReadableGit(baseDirectory.value),
     gitRunner := ConsoleGitRunner,
     gitHeadCommit := gitReader.value.withGit(_.headCommitSha),
+    gitHeadCommitDate := gitReader.value.withGit(_.headCommitDate),
     gitTagToVersionNumber := git.defaultTagByVersionStrategy,
     gitDescribedVersion := gitReader.value.withGit(_.describedVersion).map(v => git.gitTagToVersionNumber.value(v).getOrElse(v)),
     gitCurrentTags := gitReader.value.withGit(_.currentTags),
@@ -184,6 +186,7 @@ object SbtGit {
     val branch = GitKeys.gitBranch
     val runner = GitKeys.gitRunner in ThisBuild
     val gitHeadCommit = GitKeys.gitHeadCommit in ThisBuild
+    val gitHeadCommitDate = GitKeys.gitHeadCommitDate in ThisBuild
     val useGitDescribe = GitKeys.useGitDescribe in ThisBuild
     val gitDescribedVersion = GitKeys.gitDescribedVersion in ThisBuild
     val gitCurrentTags = GitKeys.gitCurrentTags in ThisBuild
@@ -205,7 +208,7 @@ object SbtGit {
     def defaultFormatShaVersion(baseVersion: Option[String], sha:String, suffix: String):String = {
       baseVersion.map(_ +"-").getOrElse("") + sha + suffix
     }
-    
+
     def defaultFormatDateVersion(baseVersion:Option[String], date:java.util.Date):String = {
         val df = new java.text.SimpleDateFormat("yyyyMMdd'T'HHmmss")
         df setTimeZone java.util.TimeZone.getTimeZone("GMT")

--- a/src/main/scala/com/typesafe/sbt/git/JGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGit.scala
@@ -97,14 +97,14 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
 
   override def headCommitDate: Option[String] = {
     val walk = new RevWalk(repo)
-    headCommit.map({ id =>
+    headCommit.map { id =>
       val commit = walk.parseCommit(id)
       val seconds = commit.getCommitTime.toLong
       val millis = seconds * 1000L
       val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
       format.setTimeZone(commit.getCommitterIdent.getTimeZone)
       format.format(new Date(millis))
-    })
+    }
   }
 }
 

--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -11,12 +11,14 @@ trait GitReadonlyInterface {
   def branch: String
   /** The current commit SHA of the local repository, or none. */
   def headCommitSha: Option[String]
+  /** The current commit date of the local repository in ISO-8601 format, or none. */
+  def headCommitDate: Option[String]
   /** The current tags associated with the local repository (at its HEAD). */
   def currentTags: Seq[String]
   /** Version of the software as returned by `git describe --tags`. */
   def describedVersion: Option[String]
   /** Whether there are uncommitted changes (i.e. whether any tracked file has changed) */
-  def hasUncommittedChanges: Boolean 
+  def hasUncommittedChanges: Boolean
   /** The local branches */
   def branches : Seq[String]
   /** The remote branches */


### PR DESCRIPTION
This PR adds the ability to read the date of the current HEAD commit.

As the return value I've chosen an ISO formatted string of the datetime instead of returning a `java.util.Date`. This is because `Date` is gross and the reliance on an old Java version does not allow using `java.time.OffsetDateTime`.