### PR TITLE
Default value for scmInfo

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -117,7 +117,18 @@ object SbtGit {
     gitDescribedVersion := gitReader.value.withGit(_.describedVersion).map(v => git.gitTagToVersionNumber.value(v).getOrElse(v)),
     gitCurrentTags := gitReader.value.withGit(_.currentTags),
     gitCurrentBranch := Option(gitReader.value.withGit(_.branch)).getOrElse(""),
-    gitUncommittedChanges in ThisBuild := gitReader.value.withGit(_.hasUncommittedChanges)
+    gitUncommittedChanges in ThisBuild := gitReader.value.withGit(_.hasUncommittedChanges),
+    scmInfo := {
+      val remote = """origin[ \t]+git@([^:]*):(.*)\.git[ \t]+\(fetch\)""".r
+      Process("git remote -v").lines_!.collect {
+        case remote(domain, repo) =>
+          ScmInfo(
+            url(s"https://$domain/$repo"),
+            s"scm:git:https://$domain/$repo.git",
+            Some(s"scm:git:git@$domain:$repo.git")
+          )
+      }.headOption
+    }
   )
   val projectSettings = Seq(
     // Input task to run git commands directly.

--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -119,7 +119,8 @@ object SbtGit {
     gitCurrentBranch := Option(gitReader.value.withGit(_.branch)).getOrElse(""),
     gitUncommittedChanges in ThisBuild := gitReader.value.withGit(_.hasUncommittedChanges),
     scmInfo := {
-      val remote = """origin[ \t]+git@([^:]*):(.*)\.git[ \t]+\(fetch\)""".r
+      val remote = """origin[ \t]+(?:git@|https?\:\/\/)([^:\/]+)[:\/](.*)\.git[ \t]+\(fetch\)""".r
+      
       Process("git remote -v").lines_!.collect {
         case remote(domain, repo) =>
           ScmInfo(


### PR DESCRIPTION
Uses Git to automatically initialize scmInfo field with a default value so no special configuration is needed to deploy to Sonatype. #113 