### PR TITLE
fix warning. remove `val` in for comprehension

### DIFF
--- a/project/bintray.scala
+++ b/project/bintray.scala
@@ -20,7 +20,7 @@ object Bintray extends AutoPlugin {
       for {
         c <- creds
         if c.isInstanceOf[sbt.DirectCredentials]
-        val cred = c.asInstanceOf[sbt.DirectCredentials]
+        cred = c.asInstanceOf[sbt.DirectCredentials]
         if cred.host == "api.bintray.com"
       } yield cred.userName -> cred.passwd
 


### PR DESCRIPTION
```
sbt-git/project/bintray.scala:23: val keyword in for comprehension is deprecated
[warn]         val cred = c.asInstanceOf[sbt.DirectCredentials]
[warn]                  ^
[warn] one warning found
```