### PR TITLE
Upgrade sbt, remove transitive dep on Log4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ libraryDependencies ++= Seq(
     exclude("javax.jms", "jms")
     exclude("com.sun.jdmk", "jmxtools")
     exclude("com.sun.jmx", "jmxri")
+    exclude("org.slf4j", "slf4j-log4j12")
 )
 
 scriptedSettings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git"     % "0.8.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git"     % "0.9.0")
 addSbtPlugin("me.lessis"        % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
I have removed the transitive dependency on Log4j 1 introduced by jGit in order to allow users to use their favorite logging library, e.g. Log4j 2 or Logback.