### PR TITLE
Use correct jgit artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ addons:
   hosts:
     - myshorthost
   hostname: myshorthost
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+
 script:
   - sbt test
   - sbt scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: scala
+# apparently the hosts file needs to be prefilled
+# https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+addons:
+  hosts:
+    - myshorthost
+  hostname: myshorthost
 script:
   - sbt test
   - sbt scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+sudo: false
 # apparently the hosts file needs to be prefilled
 # https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
 addons:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further detail
 
 To get rid of them, you can force the SLF4J no-op binder by adding `libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"` to `~/.sbt/0.13/plugins/plugins.sbt`
 
+## Running the tests
+
+Tests for this plugin are written using `sbt-scripted`. Test can be executed with 
+
+```
+sbt scripted
+```
+
 ## Licensing ##
 
 This software is licensed under the BSD license.

--- a/build.sbt
+++ b/build.sbt
@@ -13,12 +13,7 @@ enablePlugins(GitVersioning)
 git.baseVersion := "0.9"
 
 libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "4.5.0.201609210915-r"
-    exclude("javax.jms", "jms")
-    exclude("com.sun.jdmk", "jmxtools")
-    exclude("com.sun.jmx", "jmxri")
-    exclude("org.slf4j", "slf4j-log4j12")
-    exclude("log4j", "log4j")
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.7.0.201704051617-r"
 )
 
 scriptedSettings

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ enablePlugins(GitVersioning)
 git.baseVersion := "0.9"
 
 libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.7.0.201704051617-r"
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.0.201609210915-r"
 )
 
 scriptedSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git"     % "0.9.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git"     % "0.9.2")
 addSbtPlugin("me.lessis"        % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
This PR introduces `org.eclipse.jgit`as the main artifact for use in this plugin.

I cannot find any information on what `org.eclipse.jgit.pgm` is but it includes a large amount of unnecessary dependencies like the servlet API, jetty and other things that this plugin definitely doesn't need.