### PR TITLE
Add `useReachableTags` setting to allow searching beyond HEAD for tag matching.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -15,6 +15,8 @@ trait GitReadonlyInterface {
   def headCommitDate: Option[String]
   /** The current tags associated with the local repository (at its HEAD). */
   def currentTags: Seq[String]
+  /** Tags reachable from HEAD, in order. */
+  def reachableTags: Seq[String]
   /** Version of the software as returned by `git describe --tags`. */
   def describedVersion: Option[String]
   /** Whether there are uncommitted changes (i.e. whether any tracked file has changed) */


### PR DESCRIPTION
Relates to #93.

This is very much thrown up "for discussion" rather than necessarily expecting it to be implemented in its current form.

Particularly, it's currently quite inefficient as it involves checking all tags against all parent commits of HEAD.  But I thought the configuration interface (and whether or not the functionality is acceptable at all!) could be discussed before the implementation is optimised.