### PR TITLE
Upgrade JGit and SBT 1.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   include:
   - env: SBT_VERSION="0.13.16"
     jdk: oraclejdk8
-  - env: SBT_VERSION="1.0.0-RC3"
+  - env: SBT_VERSION="1.0.3"
     jdk: oraclejdk8
 script:
   - sbt "^^${SBT_VERSION}" test scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_cache:
 matrix:
   include:
   - env: SBT_VERSION="0.13.16"
-    jdk: openjdk7
+    jdk: oraclejdk8
   - env: SBT_VERSION="1.0.0-RC3"
     jdk: oraclejdk8
 script:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ well as allowing other plugins to make use of git.
 
 
 ## Installation ##
-This plugin now requires at least **Java 7** (the latest version supporting Java 6 was `0.8.5`)
+This plugin now requires at least **Java 8** (the latest version supporting Java 7 was `0.9.3`)
 
 Latest:
 
 Add the following to your `project/plugins.sbt` or `~/.sbt/0.13/plugins/plugins.sbt` file:
 
-    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.10.0")
 
 Prior to sbt 0.13.5:
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ well as allowing other plugins to make use of git.
 
 
 ## Installation ##
-This plugin now requires at least **Java 8** (the latest version supporting Java 7 was `0.9.3`)
+As of `0.10.0` (not released yet) this plugin requires at least **Java 8**.
+The latest version supporting Java 7 was `0.9.3`, while the latest version supporting Java 6 was `0.8.5`.
 
 Latest:
 
 Add the following to your `project/plugins.sbt` or `~/.sbt/0.13/plugins/plugins.sbt` file:
 
-    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.10.0")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 Prior to sbt 0.13.5:
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ enablePlugins(GitVersioning)
 git.baseVersion := "0.9"
 
 libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.0.201609210915-r"
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
 )
 
 scriptedSettings

--- a/build.sbt
+++ b/build.sbt
@@ -16,5 +16,4 @@ libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
 )
 
-scriptedSettings
 scriptedLaunchOpts += s"-Dproject.version=${version.value}"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"     % "0.9.3")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")

--- a/src/main/scala/com/typesafe/sbt/git/JGitRunner.scala
+++ b/src/main/scala/com/typesafe/sbt/git/JGitRunner.scala
@@ -64,10 +64,10 @@ object JGitRunner extends GitRunner {
          val baos = new java.io.ByteArrayOutputStream
 			// NOTE: this will always return 0 until sbt 0.13.1 due to the use of CustomOutput
          val code = Fork.java.fork(ForkOptions(
-          javaHome = Option.empty[java.io.File],
-          outputStrategy = Option[OutputStrategy](CustomOutput(baos)),
-          bootJars = Vector.empty[java.io.File],
-          workingDirectory = Option(cwd),
+          javaHome = None,
+          outputStrategy = Some(CustomOutput(baos)),
+          bootJars = Vector.empty[File],
+          workingDirectory = Some(cwd),
           runJVMOptions = Vector.empty[String],
           connectInput = false,
           envVars = Map.empty[String, String]),

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.3

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.16


### PR DESCRIPTION
I wanted to upgrade the version of JGit, so that we can begin to make use of new features.

In order to do so, as noted in existing PR #121 (which I believe is superseded by this PR), we need to bump the version of the JDK, since JGit no longer supports Java 7.

While I was at it, it seemed like a good opportunity to bump the 1.0.x track of SBT to be `1.0.3` instead of a release candidate.

Could I have a review of this, please?