### PR TITLE
Pick the higher version if there are multiple on the current commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can begin to use git to control your project versions.
 The git plugin will now autogenerate your version using the following rules, in order:
 
 1. Looks at version-property setting (default to `project.version`), and checks the `sys.props` to see if this has a value.  If so, use it.
-2. Otherwise, looks at the project tags.  The first to match the `gitTagToVersionNumberSetting` is used to assign the version.  The default is to look for tags that begin with `v` and a number, and use the number as the version.
+2. Otherwise, looks at the project tags. The first to match the `gitTagToVersionNumberSetting` is used to assign the version.  The default is to look for tags that begin with `v` and a number, and use the number as the version. If there are multiple version tags, it will pick the highest.
 3. If no tags are found either, look at the head commit. We attach this to the `git.baseVersion` setting: "&lt;base-version&gt;.&lt;git commit sha&gt;"
 4. If no head commit is present either (which means this is a brand-new repository with no commits yet), we append the current timestamp to the base version: "&lt;base-version&gt;.&lt;timestamp&gt;".
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ enablePlugins(GitVersioning, SbtPlugin)
 git.baseVersion := "1.0"
 
 libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r",
+  "com.michaelpollmeier" % "versionsort" % "1.0.0"
 )
 
 scriptedLaunchOpts += s"-Dproject.version=${version.value}"

--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -263,7 +263,7 @@ object SbtGit {
           version <- releaseTagVersion(tag)
         } yield version + suffix
       // NOTE - Selecting the last tag or the first tag should be an option.
-      releaseVersions.reverse.headOption
+      releaseVersions.sortWith { versionsort.VersionHelper.compare(_, _) > 0 }.headOption
     }
     def overrideVersion(versionProperty: String) = Option(sys.props(versionProperty))
 


### PR DESCRIPTION
Currently, when there are multiple version tags on the current commit, one is picked semi-randomly. I say `semi` because it's actually deterministic, but it doesn't quite make sense. Anyway, if there are two tags, it typically picks the highest one, unless the last segment has more decimals (e.g. it picks `0.9` over `0.10`, and `0.99` over `0.100`).
```
git tag v0.1
git tag v0.2
sbt 'show version' #0.2

git tag v0.9
git tag v0.10
sbt 'show version' #0.9
```
Technically you could say "who cares, it's the same commit anyway", but if you then publish the package to the jar repository, you have to pick the right one, and that's the one with the higher version - because the latter one is likely already published and it will fail on the attempt to re-publish.

Note: the [sort algo](https://github.com/mpollmeier/versionsort/blob/master/src/main/java/versionsort/VersionHelper.java) is short enough to copy it (and it's tests) into this repo, if you want to save a dependency. That jar has zero dependencies though (not even scala). I use it for another project and just published it to maven central.