### PR TITLE
#110

### DIFF
--- a/src/main/scala/com/typesafe/sbt/git/ConsoleGitReadableOnly.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ConsoleGitReadableOnly.scala
@@ -1,0 +1,27 @@
+package com.typesafe.sbt.git
+
+import scala.util.Try
+
+import sbt.{File, Logger}
+
+class ConsoleGitReadableOnly(git: GitRunner, cwd: File, log: Logger) extends GitReadonlyInterface {
+  def branch: String = git("rev-parse", "--abbrev-ref", "HEAD")(cwd, log)
+
+  def headCommitSha: Option[String] = Try(git("rev-parse", "HEAD")(cwd, log)).toOption
+
+  def headCommitDate: Option[String] = Try(git("log", """--pretty="%cI"""", "-n", "1")(cwd, log)).toOption
+
+  def currentTags: Seq[String] = git("tag", "--points-at", "HEAD")(cwd, log).split("\\s+")
+
+  def describedVersion: Option[String] = git("describe", "--tags")(cwd, log).split("\\s+").headOption
+
+  def hasUncommittedChanges: Boolean = git("status")(cwd, log).contains("nothing to commit, working tree clean")
+
+  def branches: Seq[String] = git("branch", "--list")(cwd, log).split("\\s+")
+
+  def remoteBranches: Seq[String] = git("branch", "-l", "--remotes")(cwd, log).split("\\s+")
+
+  def remoteOrigin: String = git("ls-remote", "--get-url", "origin")(cwd, log)
+
+  def headCommitMessage: Option[String] = Try(git("log", "--pretty=%s\n\n%b", "-n", "1")(cwd, log)).toOption
+}

--- a/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/typesafe/sbt/git/ReadableGit.scala
@@ -31,11 +31,13 @@ trait GitReadonlyInterface {
 }
 
 
-/** Our default readable git uses JGit instead of a process-forking and reading, for speed/safety. */
-final class DefaultReadableGit(base: sbt.File) extends ReadableGit {
+/** Our default readable git uses JGit instead of a process-forking and reading, for speed/safety. However, we allow
+  * overriding, since JGit doesn't currently work with git worktrees
+  * */
+final class DefaultReadableGit(base: sbt.File, gitOverride: Option[GitReadonlyInterface]) extends ReadableGit {
   // TODO - Should we cache git, or just create on each request?
   // For now, let's cache.
-  private[this] val git = JGit(base)
+  private[this] val git = gitOverride getOrElse JGit(base)
   /** Use the git read-only interface. */
   def withGit[A](f: GitReadonlyInterface => A): A =
     // JGit has concurrency issues so we synchronize access to it.


### PR DESCRIPTION
Adds a 'useConsoleForROGit' setting, so that the plugin can be used with worktrees
Usage:

```
import com.typesafe.sbt.SbtGit._
useReadableConsoleGit
```