### PR TITLE
use openjdk instead of oraclejdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_cache:
 matrix:
   include:
   - env: SBT_VERSION="0.13.17"
-    jdk: oraclejdk8
+    jdk: openjdk8
   - env: SBT_VERSION="1.1.5"
-    jdk: oraclejdk8
+    jdk: openjdk8
 script:
   - sbt "^^${SBT_VERSION}" test scripted


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.