### PR TITLE
Make prompt more colourful

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -98,11 +98,12 @@ object SbtGit {
       val reader = extracted get GitKeys.gitReader
       val dir = extracted get baseDirectory
       val name = extracted get Keys.name
+      val end = scala.Console.BLUE + "> " + scala.Console.RESET
       if (isGitRepo(dir)) {
-        val branch = reader.withGit(_.branch)
-        name + "(" + branch + ")> "
+        val branch = scala.Console.GREEN + "[" + reader.withGit(_.branch) + "]" + scala.Console.RESET
+        name + branch + end
       } else {
-        name + "> "
+        name + end
       }
     }
   }


### PR DESCRIPTION
Giving a colour for the branch enhances the readability. It helps to better distinguish between project name and branch name.
![Screenshot_20191127_104437](https://user-images.githubusercontent.com/3511382/69713601-1b5fe700-1105-11ea-8957-8566b1cabbd5.png)
