### PR TITLE
Expose sequences as immutable Seq for Scala 2.13 compat

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGit.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGit.scala
@@ -4,6 +4,7 @@ import sbt._
 import Keys._
 import git.{ConsoleGitRunner, DefaultReadableGit, GitRunner, JGitRunner, ReadableGit}
 import sys.process.Process
+import scala.collection.immutable.Seq
 
 /** This plugin has all the basic 'git' functionality for other plugins. */
 object SbtGit {
@@ -128,7 +129,7 @@ object SbtGit {
       val unauthenticated = raw"""(?:git|https?|ftps?)\:\/\/$domain\/$gitPath""".r
       val ssh = raw"""ssh\:\/\/$user$domain\/$gitPath""".r
       val headlessSSH = raw"""$user$domain:$gitPath""".r
-      
+
       def buildScmInfo(domain: String, repo: String) = Option(
         ScmInfo(
           url(s"https://$domain/$repo"),


### PR DESCRIPTION
I'm using sbt-buildinfo to generate an object with some values based on (mostly) sbt-git keys. The object is defined to have a supertype which is a trait with a `Seq[String]` field corresponding to gitCurrentTags. Because sbt-git exposes that as a `Seq[String]` and the sbt 1.x version is built using Scala 2.13, `Seq` means `scala.collection.Seq`. However, my object wants an immutable `Seq`.

I'm submitting this in hopes it isn't a breaking change and might be accepted soon. Otherwise, I suppose I'll have to work around this by widening the type of the field in my trait.