### PR TITLE
Switch to com.github.sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Latest:
 
 Add the following to your `project/plugins.sbt` or `~/.sbt/0.13/plugins/plugins.sbt` file:
 
-    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+    addSbtPlugin("com.github.sbt" % "sbt-git" % "1.0.0")
 
 Prior to sbt 0.13.5:
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The latest version supporting Java 7 was `0.9.3`, while the latest version suppo
 
 Latest:
 
-Add the following to your `project/plugins.sbt` or `~/.sbt/0.13/plugins/plugins.sbt` file:
+Add the following to your `project/plugins.sbt` or `~/.sbt/1.0/plugins/plugins.sbt` file:
 
-    addSbtPlugin("com.github.sbt" % "sbt-git" % "1.0.0")
+    addSbtPlugin("com.github.sbt" % "sbt-git" % "<version>")
 
 Prior to sbt 0.13.5:
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-organization := "com.typesafe.sbt"
-sonatypeProfileName := "com.typesafe"
+organization := "com.github.sbt"
+sonatypeProfileName := "com.github.sbt"
 name := "sbt-git"
 licenses := Seq(("BSD-2-Clause", url("https://opensource.org/licenses/BSD-2-Clause")))
 description := "An sbt plugin that offers git features directly inside sbt"

--- a/src/sbt-test/git-versioning/find-environment-variable/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/find-environment-variable/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/find-tag-newest/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/find-tag-newest/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/find-tag/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/find-tag/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/get-message/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/get-message/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/multi-module-project/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/multi-module-project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/no-base-version/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/no-base-version/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/uncommitted-signifier/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/uncommitted-signifier/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/use-describe-with-matching/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/use-describe-with-matching/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/use-describe/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/use-describe/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/with-base-version/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/with-base-version/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))


### PR DESCRIPTION
Fixes #198

I think it could be that after merging this pull request we already see a snapshot here: https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/sbt/