### PR TITLE
Configure scala-steward not to update to JGit 6

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.pin  = [
+  # JGit 6 requires Java 11, see #213
+  { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." }
+]


### PR DESCRIPTION
Since that requires Java 11 and we're not ready to make that requirement.

Replaces #212