### PR TITLE
Change package to com.github.sbt.git

### DIFF
--- a/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import scala.util.Try
 

--- a/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt._
 import Keys._

--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -1,8 +1,7 @@
-package com.typesafe.sbt
+package com.github.sbt.git
 
 import sbt._
 import Keys._
-import git.{ConsoleGitReadableOnly, ConsoleGitRunner, DefaultReadableGit, GitRunner, JGitRunner, ReadableGit}
 import sys.process.Process
 
 /** This plugin has all the basic 'git' functionality for other plugins. */

--- a/src/main/scala/com/github/sbt/git/GitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/GitRunner.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt._
 

--- a/src/main/scala/com/github/sbt/git/JGit.scala
+++ b/src/main/scala/com/github/sbt/git/JGit.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder

--- a/src/main/scala/com/github/sbt/git/JGitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/JGitRunner.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt._
 import Keys._

--- a/src/main/scala/com/github/sbt/git/NullLogger.scala
+++ b/src/main/scala/com/github/sbt/git/NullLogger.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt.LogEvent
 import sbt.Level

--- a/src/main/scala/com/github/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/github/sbt/git/ReadableGit.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 /** An interface for interacting with git in a read-only manner. */
 trait ReadableGit {

--- a/src/test/scala/com/github/sbt/git/SbtGitSuite.scala
+++ b/src/test/scala/com/github/sbt/git/SbtGitSuite.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt
+package com.github.sbt.git
 
 import sbt.ScmInfo
 import sbt.url


### PR DESCRIPTION
To prevent classpath problems when it is on the same classpath with the sbt-git when it was published with the old

Not for merge yet: need to check whether having 'overlapping' autoplugins confuses sbt.

Refs #216