### PR TITLE
Change package to `com.github.sbt.git`

### DIFF
--- a/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import scala.util.Try
 

--- a/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt._
 import Keys._

--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -1,8 +1,7 @@
-package com.typesafe.sbt
+package com.github.sbt.git
 
 import sbt._
 import Keys._
-import git.{ConsoleGitReadableOnly, ConsoleGitRunner, DefaultReadableGit, GitRunner, JGitRunner, ReadableGit}
 import sys.process.Process
 
 /** This plugin has all the basic 'git' functionality for other plugins. */

--- a/src/main/scala/com/github/sbt/git/GitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/GitRunner.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt._
 

--- a/src/main/scala/com/github/sbt/git/JGit.scala
+++ b/src/main/scala/com/github/sbt/git/JGit.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder

--- a/src/main/scala/com/github/sbt/git/JGitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/JGitRunner.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt._
 import Keys._

--- a/src/main/scala/com/github/sbt/git/NullLogger.scala
+++ b/src/main/scala/com/github/sbt/git/NullLogger.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 import sbt.LogEvent
 import sbt.Level

--- a/src/main/scala/com/github/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/github/sbt/git/ReadableGit.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.git
+package com.github.sbt.git
 
 /** An interface for interacting with git in a read-only manner. */
 trait ReadableGit {

--- a/src/test/scala/com/github/sbt/git/SbtGitSuite.scala
+++ b/src/test/scala/com/github/sbt/git/SbtGitSuite.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt
+package com.github.sbt.git
 
 import sbt.ScmInfo
 import sbt.url


### PR DESCRIPTION
Revives https://github.com/sbt/sbt-git/pull/217, just so there is at least one path forward.

https://github.com/sbt/sbt-git/issues/216 discusses some ideas to publish a transitional artifact under the old group id, but I don't how hard that would be and/or who can do that, since this repo is now setup for CI release on the new group id.

https://github.com/sbt/sbt-git/pull/217 notes that if the old/new version of the plugin end up on the same build, the build will break. But that's not the end of the world: it's no different than a fatal eviction error due to a version incompatibility. In any case, it's better than non-determinate behavior if the package was kept the same.

IMO if it's possible to keep publishing to the old group id, instead of trying to do a transitional-artifact-hack the plugin should consider to continue publishing under the old group id since that would avoid this whole mess. The switch to the new group id can happen concurrently to the breaking update to JGit 6 in https://github.com/sbt/sbt-git/issues/213.
