### PR TITLE
Fix console reader issues

### DIFF
--- a/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
@@ -11,15 +11,15 @@ class ConsoleGitReadableOnly(git: GitRunner, cwd: File, log: Logger) extends Git
 
   def headCommitDate: Option[String] = Try(git("log", """--pretty="%cI"""", "-n", "1")(cwd, log)).toOption
 
-  def currentTags: Seq[String] = git("tag", "--points-at", "HEAD")(cwd, log).split("\\s+")
+  def currentTags: Seq[String] = Try(git("tag", "--points-at", "HEAD")(cwd, log).split("\\s+").toSeq).getOrElse(Seq())
 
-  def describedVersion: Option[String] = git("describe", "--tags")(cwd, log).split("\\s+").headOption
+  def describedVersion: Option[String] = Try(git("describe", "--tags")(cwd, log).split("\\s+").headOption).toOption.flatten
 
-  def hasUncommittedChanges: Boolean = git("status")(cwd, log).contains("nothing to commit, working tree clean")
+  def hasUncommittedChanges: Boolean = Try(!git("status", "-s")(cwd, log).trim.isEmpty).getOrElse(true)
 
-  def branches: Seq[String] = git("branch", "--list")(cwd, log).split("\\s+")
+  def branches: Seq[String] = Try(git("branch", "--list")(cwd, log).split("\\s+").toSeq).getOrElse(Seq())
 
-  def remoteBranches: Seq[String] = git("branch", "-l", "--remotes")(cwd, log).split("\\s+")
+  def remoteBranches: Seq[String] = Try(git("branch", "-l", "--remotes")(cwd, log).split("\\s+").toSeq).getOrElse(Seq())
 
   def remoteOrigin: String = git("ls-remote", "--get-url", "origin")(cwd, log)
 

--- a/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
@@ -54,6 +54,9 @@ object ConsoleGitRunner extends GitRunner {
     def buffer[T](f: => T): T = f
 
     private def print(desiredLevel: LogLevel)(t: (LogLevel, String)): String = t match {
+      case (Debug, msg) =>
+        log.debug(msg)
+        msg
       case (Info, msg) =>
         log.info(msg)
         msg

--- a/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitRunner.scala
@@ -37,12 +37,12 @@ object ConsoleGitRunner extends GitRunner {
   // reduce log level for git process
   private class GitLogger(log: Logger) extends ProcessLogger {
     import scala.collection.mutable.ListBuffer
-    import Level.{ Info, Warn, Error, Value => LogLevel }
+    import Level.{ Debug, Info, Warn, Error, Value => LogLevel }
 
     private val msgs: ListBuffer[(LogLevel, String)] = new ListBuffer()
 
     def info(s: => String): Unit =
-      synchronized { msgs += ((Info, s)) }
+      synchronized { msgs += ((Debug, s)) }
 
     def error(s: => String): Unit =
       synchronized { msgs += ((Error, s)) }
@@ -63,7 +63,7 @@ object ConsoleGitRunner extends GitRunner {
     }
 
     def flush(exitCode: Int): String = {
-      val level = if (exitCode == 0) Info else Error // reduce log level Error -> Info if exitCode is zero
+      val level = if (exitCode == 0) Debug else Error // reduce log level Error -> Debug if exitCode is zero
       var result = msgs map print(level)
       msgs.clear()
       result.mkString("\n")

--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -113,7 +113,7 @@ object SbtGit {
   import GitKeys._
   def buildSettings = Seq(
     useConsoleForROGit := false,
-    gitReader := new DefaultReadableGit(baseDirectory.value, if (useConsoleForROGit.value) Some(new ConsoleGitReadableOnly(ConsoleGitRunner, file("."), ConsoleLogger())) else None),
+    gitReader := new DefaultReadableGit(baseDirectory.value, if (useConsoleForROGit.value) Some(new ConsoleGitReadableOnly(ConsoleGitRunner, file("."), sLog.value)) else None),
     gitRunner := ConsoleGitRunner,
     gitHeadCommit := gitReader.value.withGit(_.headCommitSha),
     gitHeadMessage := gitReader.value.withGit(_.headCommitMessage),


### PR DESCRIPTION
Three issues! First, loads of commands can crash under certain circumstances, such as when cloned without tags. Wrapping everything in `Try` should fix this. Second, grepping `git status` is very much the wrong way to look for uncommitted changes. This is why `git status -s` exists. Third, the logger is *very* chatty, so I made it configurable and dropped the default level to `Debug`.

This is blocking typelevel/cats-effect#2942