### PR TITLE
Adding a describedVersion(...) for ConsoleGitReadableOnly

### DIFF
--- a/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
+++ b/src/main/scala/com/github/sbt/git/ConsoleGitReadableOnly.scala
@@ -15,6 +15,11 @@ class ConsoleGitReadableOnly(git: GitRunner, cwd: File, log: Logger) extends Git
 
   def describedVersion: Option[String] = Try(git("describe", "--tags")(cwd, log).split("\\s+").headOption).toOption.flatten
 
+  override def describedVersion(patterns: Seq[String]): Option[String] =
+    patterns.headOption.fold(describedVersion)(pat =>
+      Try(git("describe", "--tags", "--match", pat)(cwd, log).split("\\s+").headOption).toOption.flatten
+    )
+
   def hasUncommittedChanges: Boolean = Try(!git("status", "-s")(cwd, log).trim.isEmpty).getOrElse(true)
 
   def branches: Seq[String] = Try(git("branch", "--list")(cwd, log).split("\\s+").toSeq).getOrElse(Seq())


### PR DESCRIPTION
In monorepos (in this example [guardrail](https://github.com/guardrail-dev/guardrail)), the same ref will occasionally have multiple tags.

Relying on `git describe` without `--match` could resolve the wrong tag for different modules.

Unfortunately JGit still does not support git worktree (though that seems to be [coming soon](https://bugs.eclipse.org/bugs/show_bug.cgi?id=477475)!), so I'm stuck on CLI git.

Thank you