### PR TITLE
Use SemVer precedence when selecting release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The git plugin will now autogenerate your version using the following rules, in 
 
 The `git.baseVersion` setting represents the in-development (upcoming) version you're working on.
 
+When all matching versions can be parsed as SemVer (including short versions such as `1` and `1.2`),
+the highest version is selected using SemVer precedence. Build metadata does not affect precedence;
+the first tag wins when versions have equal precedence. The selected version's original text is preserved.
+If any matching version cannot be parsed this way, the existing `versionsort` ordering is used for all
+matching versions, preserving support for other version formats such as `1.2.3.4`.
+
 You can alter the tag-detection algorithm using the `git.gitTagToVersionNumber` setting. For example, if we wanted to alter the default version tag detection so it does not require a "v" at the start of tags, we could add the following setting:
 
     git.gitTagToVersionNumber := { tag: String =>

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ enablePlugins(SbtPlugin)
 libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.5.202508271544-r",
   "com.michaelpollmeier" % "versionsort" % "1.0.17",
+  "com.github.zafarkhaja" % "java-semver" % "0.10.2",
   "org.scalameta" %% "munit" % "1.3.5" % Test
 )
 

--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -2,6 +2,7 @@ package com.github.sbt.git
 
 import sbt.*
 import Keys.*
+import com.github.zafarkhaja.semver.Version
 
 /** This plugin has all the basic 'git' functionality for other plugins. */
 object SbtGit {
@@ -318,7 +319,18 @@ object SbtGit {
         } yield version
 
       // NOTE - Selecting the last tag or the first tag should be an option.
-      val highestVersion = versions.sortWith { versionsort.VersionHelper.compare(_, _) > 0 }.headOption
+      // Lenient parsing accepts short versions such as 1.2. Keep the original strings for the result.
+      val parsedVersions = versions.map(v => v -> Version.tryParse(v, false))
+      val highestVersion =
+        if (parsedVersions.forall(_._2.isPresent))
+          parsedVersions
+            .sortWith { case ((_, a), (_, b)) => a.get.compareToIgnoreBuildMetadata(b.get) > 0 }
+            .headOption
+            .map(_._1)
+        else
+          // Custom tag conversions may return non-SemVer versions, such as 1.2.3.4.
+          // Use one ordering for the whole set so that comparisons remain transitive.
+          versions.sortWith { versionsort.VersionHelper.compare(_, _) > 0 }.headOption
       highestVersion.map(_ + suffix)
     }
 

--- a/src/sbt-test/git-versioning/find-tag-newest/test
+++ b/src/sbt-test/git-versioning/find-tag-newest/test
@@ -13,3 +13,16 @@ $ copy-file changes/build.sbt build.sbt
 > git tag v1.2.0
 > reload
 > checkVersion 1.2.0
+> git tag v1.3.0-beta.2
+> git tag v1.3.0-beta.11
+> reload
+> checkVersion 1.3.0-beta.11
+> git tag v1.3.0-beta.2147483648
+> reload
+> checkVersion 1.3.0-beta.2147483648
+> git tag v1.3.0
+> reload
+> checkVersion 1.3.0
+> git tag v1.4.0+build.007
+> reload
+> checkVersion 1.4.0+build.007

--- a/src/test/scala/com/github/sbt/git/ReleaseVersionSuite.scala
+++ b/src/test/scala/com/github/sbt/git/ReleaseVersionSuite.scala
@@ -1,0 +1,75 @@
+package com.github.sbt.git
+
+class ReleaseVersionSuite extends munit.FunSuite {
+  private def release(versions: Seq[String], suffix: String = ""): Option[String] =
+    SbtGit.git.releaseVersion(versions.map("v" + _), SbtGit.git.defaultTagByVersionStrategy, suffix)
+
+  private def assertHighest(lower: String, higher: String): Unit = {
+    assertEquals(release(Seq(lower, higher)), Some(higher))
+    assertEquals(release(Seq(higher, lower)), Some(higher))
+  }
+
+  test("orders the SemVer precedence examples in either tag order") {
+    val versions = Seq("1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0")
+    for {
+      (higher, index) <- versions.zipWithIndex
+      lower <- versions.take(index)
+    } assertHighest(lower, higher)
+  }
+
+  test("compares the core before pre-release identifiers") {
+    assertHighest("1.0.0", "1.0.1-alpha-1")
+    assertHighest("1.9.0", "1.10.0-beta.1")
+    assertHighest("1.99.99", "2.0.0-alpha")
+  }
+
+  test("compares numeric pre-release identifiers numerically and below text") {
+    assertHighest("1.0.0-beta.2", "1.0.0-beta.11")
+    assertHighest("1.0.0-99", "1.0.0-alpha")
+    assertHighest("1.0.0-beta.2147483647", "1.0.0-beta.2147483648")
+  }
+
+  test("compares pre-release text in ASCII order and preserves hyphens within identifiers") {
+    assertHighest("1.0.0-BETA", "1.0.0-alpha")
+    assertHighest("1.0.0-alpha-10", "1.0.0-alpha-2")
+  }
+
+  test("ignores build metadata for precedence and keeps the first equivalent version") {
+    for (versions <- Seq(Seq("1.0.0+aaa", "1.0.0+zzz"), Seq("1.0.0", "1.0.0+build.1"), Seq("1.0.0-beta.2+aaa", "1.0.0-beta.2+zzz"))) {
+      assertEquals(release(versions), versions.headOption)
+      assertEquals(release(versions.reverse), versions.reverse.headOption)
+    }
+    assertHighest("1.0.0+999", "1.0.1+1")
+  }
+
+  test("accepts short versions without normalizing the selected text") {
+    assertHighest("1", "2")
+    assertHighest("1.9", "1.10")
+    assertHighest("1.0-alpha", "1.0")
+    assertEquals(release(Seq("1.0", "1.0.0")), Some("1.0"))
+    assertEquals(release(Seq("1.0.0", "1.0")), Some("1.0.0"))
+  }
+
+  test("preserves the selected metadata and appends the uncommitted suffix") {
+    assertEquals(release(Seq("1.0.0", "1.1.0-rc.1+build.007"), "-SNAPSHOT"), Some("1.1.0-rc.1+build.007-SNAPSHOT"))
+  }
+
+  test("retains legacy ordering when a version is outside the SemVer parser") {
+    assertHighest("1.2.3", "1.2.3.4")
+    assertHighest("1.2.3.4", "1.2.4")
+    assertHighest("1.0.0", "1.0.0a")
+    for (versions <- Seq("1.0.0m", "1.0.0+aaa", "1.0.0+zzz").permutations)
+      assertEquals(release(versions), Some("1.0.0+zzz"))
+  }
+
+  test("retains a single custom version and handles no matching tags") {
+    assertEquals(SbtGit.git.releaseVersion(Seq("custom"), Some(_), "-dirty"), Some("custom-dirty"))
+    assertEquals(SbtGit.git.releaseVersion(Seq("unrelated"), SbtGit.git.defaultTagByVersionStrategy, ""), None)
+    assertEquals(release(Nil), None)
+  }
+
+  test("orders the versions returned by a custom tag conversion") {
+    val convert: String => Option[String] = tag => Some(tag.stripPrefix("release-"))
+    assertEquals(SbtGit.git.releaseVersion(Seq("release-1.0.0-beta.2", "release-1.0.0-beta.11"), convert, ""), Some("1.0.0-beta.11"))
+  }
+}


### PR DESCRIPTION
When several version tags point to HEAD, release selection should use SemVer precedence. The original failure involved labeled tags (#192). Current `versionsort` handles ordinary pre-releases, but still throws `NumberFormatException` for `1.0.0-beta.2147483648` and lets build metadata affect the selected version.

Use `java-semver` 0.10.2 to compare SemVer versions, with lenient parsing for existing short versions such as `1.0`. Compare without build metadata and return the original version string, retaining its spelling and metadata before appending any uncommitted suffix. Equivalent versions retain their input order.

Keep `versionsort` for compatibility when any candidate cannot be parsed as SemVer, for example `1.2.3.4` or `1.0.0a`. The fallback applies to the entire candidate set so that one consistent ordering is used. This intentionally retains the existing dependency alongside `java-semver`.

Add ten unit tests covering SemVer precedence, numeric and ASCII pre-release ordering, metadata, short versions, custom tag conversions, suffixes, and legacy formats. Extend `git-versioning/find-tag-newest` with multiple pre-release and metadata tags on the same commit. Document the selection and fallback behavior in the README.

Local validation:

- On unchanged `main` (`7ef2ceb`), the new unit suite fails for numeric pre-release overflow and metadata precedence.
- Java 8 / Scala 2.12: `++2.12.x clean scalafmtSbtCheck scalafmtCheckAll test scripted`.
- Java 17 / Scala 3: `++3.x clean scalafmtCheckAll test scripted`.

The updated branch is based on current `main`; the old maintenance commits and unrelated `test-project` change are no longer part of the diff.

The [new GitHub Actions run](https://github.com/sbt/sbt-git/actions/runs/34118454587) is awaiting maintainer approval.
