### PR TITLE
Automatic worktree detection

### DIFF
--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -112,8 +112,8 @@ object SbtGit {
   // Build settings.
   import GitKeys._
   def buildSettings = Seq(
-    useConsoleForROGit := false,
-    gitReader := new DefaultReadableGit(baseDirectory.value, if (useConsoleForROGit.value) Some(new ConsoleGitReadableOnly(ConsoleGitRunner, file("."), sLog.value)) else None),
+    useConsoleForROGit := isGitLinkedRepo(baseDirectory.value),
+    gitReader := new DefaultReadableGit(baseDirectory.value, if (useConsoleForROGit.value) Some(new ConsoleGitReadableOnly(ConsoleGitRunner, baseDirectory.value, sLog.value)) else None),
     gitRunner := ConsoleGitRunner,
     gitHeadCommit := gitReader.value.withGit(_.headCommitSha),
     gitHeadMessage := gitReader.value.withGit(_.headCommitMessage),
@@ -126,6 +126,21 @@ object SbtGit {
     ThisBuild / gitUncommittedChanges := gitReader.value.withGit(_.hasUncommittedChanges),
     scmInfo := parseScmInfo(gitReader.value.withGit(_.remoteOrigin))
   )
+
+  private def isGitLinkedRepo(dir: File): Boolean =
+    isGitWorktreeDir(Option(System.getenv("GIT_DIR")).fold(dir)(file))
+
+  @scala.annotation.tailrec
+  private def isGitWorktreeDir(dir: File): Boolean = {
+    val maybeGit = dir / ".git"
+    // In a linked worktree, .git is a file that contains the path to the main worktree.
+    if (maybeGit.exists()) maybeGit.isFile
+    else Option(dir.getParentFile) match {
+      case Some(parent) => isGitWorktreeDir(parent)
+      case None => false
+    }
+  }
+
   private[sbt] def parseScmInfo(remoteOrigin: String): Option[ScmInfo] = {
     val user = """(?:[^@\/]+@)?"""
     val domain = """([^\/]+)"""

--- a/src/sbt-test/git-versioning/worktree/.project/project/plugins.sbt
+++ b/src/sbt-test/git-versioning/worktree/.project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/git-versioning/worktree/init.sh
+++ b/src/sbt-test/git-versioning/worktree/init.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+mkdir -p main
+
+cd main
+git init
+git commit --allow-empty -m "Initial commit"
+git worktree add ../project
+cd -
+
+cp -r .project/project project

--- a/src/sbt-test/git-versioning/worktree/test
+++ b/src/sbt-test/git-versioning/worktree/test
@@ -1,0 +1,3 @@
+$ exec ./init.sh
+> reload plugins
+> show gitHeadMessage


### PR DESCRIPTION
It's a pain submitting PRs to all the repositories that use sbt-git when I want to use a git worktree. This should eliminate the need for that.