### PR TITLE
Cross build with sbt 2.0.0-M2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and test
       run: |
         gpg --import test-key.gpg
-        sbt -v clean ^test ^scripted
+        sbt -v clean +test +scripted
         rm -rf "$HOME/.ivy2/local" || true
         find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
         find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,46 @@
-organization := "com.github.sbt"
-//sonatypeProfileName := "com.github.sbt"
-name := "sbt-git"
-licenses := Seq(("BSD-2-Clause", url("https://opensource.org/licenses/BSD-2-Clause")))
-description := "An sbt plugin that offers git features directly inside sbt"
-developers := List(Developer("jsuereth", "Josh Suereth", "joshua suereth gmail com", url("http://jsuereth.com/")))
-startYear := Some(2011)
-homepage := scmInfo.value map (_.browseUrl)
-scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-git"), "scm:git:git@github.com:sbt/sbt-git.git"))
-
-//crossSbtVersions := List("1.3.13")
-
-enablePlugins(SbtPlugin)
-//TODO: enablePlugins(GitVersioning, SbtPlugin)
-//git.baseVersion := "1.0"
-
-libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.3.202401111512-r",
-  "com.michaelpollmeier" % "versionsort" % "1.0.11",
-  "org.scalameta" %% "munit" % "1.0.2" % Test
-)
-
-scriptedLaunchOpts += s"-Dproject.version=${version.value}"
-scriptedBufferLog := false
+val sbtGit = project
+  .in(file("."))
+  .enablePlugins(SbtPlugin)
+  //TODO: enablePlugins(GitVersioning, SbtPlugin)
+  .settings(
+    organization := "com.github.sbt",
+    //sonatypeProfileName := "com.github.sbt",
+    name := "sbt-git",
+    licenses := Seq(
+      ("BSD-2-Clause", url("https://opensource.org/licenses/BSD-2-Clause"))
+    ),
+    description := "An sbt plugin that offers git features directly inside sbt",
+    developers := List(
+      Developer(
+        "jsuereth",
+        "Josh Suereth",
+        "joshua suereth gmail com",
+        url("http://jsuereth.com/")
+      )
+    ),
+    startYear := Some(2011),
+    homepage := scmInfo.value map (_.browseUrl),
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/sbt/sbt-git"),
+        "scm:git:git@github.com:sbt/sbt-git.git"
+      )
+    ),
+//crossSbtVersions := List("1.3.13"),
+//git.baseVersion := "1.0",
+    libraryDependencies ++= Seq(
+      "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.3.202401111512-r",
+      "com.michaelpollmeier" % "versionsort" % "1.0.11",
+      "org.scalameta" %% "munit" % "1.0.2" % Test
+    ),
+    // [error] (Compile / doc) java.lang.ClassNotFoundException: dotty.tools.dottydoc.Main
+    packageDoc / publishArtifact := false,
+    crossScalaVersions := Seq("2.12.20", "3.3.4"),
+    (pluginCrossBuild / sbtVersion) := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.3.0"
+        case _      => "2.0.0-M2"
+      }
+    },
+    scriptedLaunchOpts += s"-Dproject.version=${version.value}"
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization := "com.github.sbt"
-sonatypeProfileName := "com.github.sbt"
+//sonatypeProfileName := "com.github.sbt"
 name := "sbt-git"
 licenses := Seq(("BSD-2-Clause", url("https://opensource.org/licenses/BSD-2-Clause")))
 description := "An sbt plugin that offers git features directly inside sbt"
@@ -8,10 +8,11 @@ startYear := Some(2011)
 homepage := scmInfo.value map (_.browseUrl)
 scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-git"), "scm:git:git@github.com:sbt/sbt-git.git"))
 
-crossSbtVersions := List("1.3.13")
+//crossSbtVersions := List("1.3.13")
 
-enablePlugins(GitVersioning, SbtPlugin)
-git.baseVersion := "1.0"
+enablePlugins(SbtPlugin)
+//TODO: enablePlugins(GitVersioning, SbtPlugin)
+//git.baseVersion := "1.0"
 
 libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.3.202401111512-r",
@@ -20,3 +21,4 @@ libraryDependencies ++= Seq(
 )
 
 scriptedLaunchOpts += s"-Dproject.version=${version.value}"
+scriptedBufferLog := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=2.0.0-M2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
+//addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")

--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -170,7 +170,7 @@ object SbtGit {
   def useJGit: Setting[_] = ThisBuild / gitRunner := JGitRunner
 
   /** Setting to use console git for readable ops, to allow working with git worktrees */
-  def useReadableConsoleGit: Setting[_] = useConsoleForROGit in ThisBuild := true
+  def useReadableConsoleGit: Setting[_] = ThisBuild / useConsoleForROGit := true
 
   /** Adapts the project prompt to show the current project name *and* the current git branch. */
   def showCurrentGitBranch: Setting[_] =

--- a/src/main/scala/com/github/sbt/git/JGit.scala
+++ b/src/main/scala/com/github/sbt/git/JGit.scala
@@ -2,14 +2,14 @@ package com.github.sbt.git
 
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.eclipse.jgit.api.{Git => PGit}
+import org.eclipse.jgit.api.Git as PGit
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Ref
-import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
+import org.eclipse.jgit.revwalk.RevWalk
 
 import scala.util.Try
 
@@ -29,13 +29,13 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
   def branch: String = repo.getBranch
 
   private def branchesRef: Seq[Ref] = {
-    import collection.JavaConverters._
-    porcelain.branchList.call.asScala
+    import collection.JavaConverters.*
+    porcelain.branchList.call.asScala.toSeq
   }
 
   def tags: Seq[Ref] = {
-    import collection.JavaConverters._
-    porcelain.tagList.call().asScala
+    import collection.JavaConverters.*
+    porcelain.tagList.call().asScala.toSeq
   }
 
   def checkoutBranch(branch: String): Unit = {
@@ -96,9 +96,9 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
   override def branches: Seq[String] = branchesRef.filter(_.getName.startsWith("refs/heads")).map(_.getName.drop(11))
 
   override def remoteBranches: Seq[String] = {
-    import collection.JavaConverters._
+    import collection.JavaConverters.*
     import org.eclipse.jgit.api.ListBranchCommand.ListMode
-    porcelain.branchList.setListMode(ListMode.REMOTE).call.asScala.filter(_.getName.startsWith("refs/remotes")).map(_.getName.drop(13))
+    porcelain.branchList.setListMode(ListMode.REMOTE).call.asScala.filter(_.getName.startsWith("refs/remotes")).map(_.getName.drop(13)).toSeq
   }
 
   override def remoteOrigin: String = {
@@ -131,9 +131,9 @@ object JGit {
 
   /** Creates a new git instance from a base directory. */
   def apply(base: File) =
-    try (new JGit({
+    try new JGit({
       new FileRepositoryBuilder().findGitDir(base).build
-    })) catch {
+    }) catch {
       // This is thrown if we never find the git base directory.  In that instance, we'll assume root is the base dir.
       case e: IllegalArgumentException =>
         val defaultGitDir = new File(base, ".git")

--- a/src/sbt-test/git-versioning/find-tag-newest/test
+++ b/src/sbt-test/git-versioning/find-tag-newest/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 > git tag v1.0.0

--- a/src/sbt-test/git-versioning/find-tag/test
+++ b/src/sbt-test/git-versioning/find-tag/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 > git tag v1.0.0

--- a/src/sbt-test/git-versioning/get-message/test
+++ b/src/sbt-test/git-versioning/get-message/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 $ copy-file changes/build.sbt build.sbt
 > reload

--- a/src/sbt-test/git-versioning/multi-module-project-use-describe/test
+++ b/src/sbt-test/git-versioning/multi-module-project-use-describe/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 > git tag -am "a version" a-1.0

--- a/src/sbt-test/git-versioning/multi-module-project/test
+++ b/src/sbt-test/git-versioning/multi-module-project/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 $ copy-file changes/build.sbt build.sbt

--- a/src/sbt-test/git-versioning/no-base-version/test
+++ b/src/sbt-test/git-versioning/no-base-version/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 $ copy-file changes/build.sbt build.sbt

--- a/src/sbt-test/git-versioning/uncommitted-signifier/test
+++ b/src/sbt-test/git-versioning/uncommitted-signifier/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 $ copy-file changes/build.sbt build.sbt

--- a/src/sbt-test/git-versioning/use-describe-with-matching/test
+++ b/src/sbt-test/git-versioning/use-describe-with-matching/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 > git tag module-1.0.0

--- a/src/sbt-test/git-versioning/use-describe/test
+++ b/src/sbt-test/git-versioning/use-describe/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 > git tag v1.0.0

--- a/src/sbt-test/git-versioning/with-base-version/test
+++ b/src/sbt-test/git-versioning/with-base-version/test
@@ -1,6 +1,8 @@
 > git init
 > git config user.email "test@jsuereth.com"
 > git config user.name "Tester"
+> git config core.hookspath /dev/null
+> git config commit.gpgsign false
 > git add README.md
 > git commit -m "test"
 $ copy-file changes/build.sbt build.sbt


### PR DESCRIPTION
Hi, this is still a draft and my first attempt at migration. I was looking to contribute to the [sbt 2.x plugin migration](https://github.com/sbt/sbt/wiki/sbt-2.x-plugin-migration) and found sbt-git to be one that's used often.

I had to disable sbt-ci-release for now, because it doesn't support 2.x yet and [uses sbt-git itself as well](https://github.com/sbt/sbt-ci-release/blob/main/project/plugins.sbt). So I think we need to do some kind of bootstrap without sbt-ci-release before we can migrate that one too?

Let me know what you think. 

Edit: apparently sbt-ci-release was migrated to 2.x just now, so I'll update my PR accordingly

Edit: it seems to be unable to resolve sbt-ci-release `1.6.1+13-1458cb0b-SNAPSHOT`, I'm probably missing something here