### PR TITLE
Update sbt 2 up to 2.0.0-M3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ homepage := scmInfo.value map (_.browseUrl)
 scmInfo := Some(ScmInfo(url("https://github.com/sbt/sbt-git"), "scm:git:git@github.com:sbt/sbt-git.git"))
 
 lazy val scala212 = "2.12.20"
-lazy val scala3 = "3.3.4"
+lazy val scala3 = "3.6.2"
 
 crossScalaVersions := Seq(scala212, scala3)
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
 (pluginCrossBuild / sbtVersion) := {
   scalaBinaryVersion.value match {
     case "2.12" => "1.5.8"
-    case _ => "2.0.0-M2"
+    case _ => "2.0.0-M3"
   }
 }
 

--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -100,9 +100,9 @@ object SbtGit {
 
     val prompt: State => String = { state =>
       val extracted = Project.extract(state)
-      val reader = extracted get GitKeys.gitReader
-      val dir = extracted get baseDirectory
-      val name = extracted get Keys.name
+      val reader = extracted `get` GitKeys.gitReader
+      val dir = extracted `get` baseDirectory
+      val name = extracted `get` Keys.name
       if (isGitRepo(dir)) {
         val branch = reader.withGit(_.branch)
         name + "(" + branch + ")> "
@@ -284,7 +284,7 @@ object SbtGit {
     val formattedDateVersion = ThisBuild / GitKeys.formattedDateVersion
 
     val defaultTagByVersionStrategy: String => Option[String] = { tag =>
-      if (tag matches "v[0-9].*") Some(tag drop 1)
+      if (tag `matches` "v[0-9].*") Some(tag drop 1)
       else None
     }
 
@@ -294,8 +294,8 @@ object SbtGit {
 
     def defaultFormatDateVersion(baseVersion: Option[String], date: java.util.Date): String = {
       val df = new java.text.SimpleDateFormat("yyyyMMdd'T'HHmmss")
-      df setTimeZone java.util.TimeZone.getTimeZone("GMT")
-      baseVersion.map(_ + "-").getOrElse("") + (df format (new java.util.Date))
+      df.setTimeZone(java.util.TimeZone.getTimeZone("GMT"))
+      baseVersion.map(_ + "-").getOrElse("") + (df.format(new java.util.Date))
     }
 
     def flaggedOptional(flag: Boolean, value: Option[String]): Option[String] =

--- a/src/main/scala/com/github/sbt/git/JGit.scala
+++ b/src/main/scala/com/github/sbt/git/JGit.scala
@@ -66,7 +66,7 @@ final class JGit(val repo: Repository) extends GitReadonlyInterface {
       taghash = tagHash(unpeeledTag)
       if taghash == hash
       ref = unpeeledTag.getName
-      if ref startsWith "refs/tags/"
+      if ref `startsWith` "refs/tags/"
     } yield ref drop 10
   }
 

--- a/src/main/scala/com/github/sbt/git/ReadableGit.scala
+++ b/src/main/scala/com/github/sbt/git/ReadableGit.scala
@@ -36,7 +36,7 @@ trait GitReadonlyInterface {
 final class DefaultReadableGit(base: sbt.File, gitOverride: Option[GitReadonlyInterface]) extends ReadableGit {
   // TODO - Should we cache git, or just create on each request?
   // For now, let's cache.
-  private[this] val git = gitOverride getOrElse JGit(base)
+  private val git = gitOverride getOrElse JGit(base)
   /** Use the git read-only interface. */
   def withGit[A](f: GitReadonlyInterface => A): A =
     // JGit has concurrency issues so we synchronize access to it.


### PR DESCRIPTION
According to https://eed3si9n.com/sbt-2.0.0-M3 the M2 and M3 are not binary compatible, so we need a new sbt-git release.