### PR TITLE
Remove `GitVersioning` plugin, we use sbt-ci-release + dynver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val scala3 = "3.6.4"
 
 crossScalaVersions := Seq(scala212, scala3)
 
-enablePlugins(GitVersioning, SbtPlugin)
+enablePlugins(SbtPlugin)
 git.baseVersion := "1.0"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
snapshots are not correctly versioned: https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/sbt/sbt-git_2.12_1.0/