### PR TITLE
Exclude sbt-git's own keys from sbt's lintUnused check

### DIFF
--- a/src/main/scala/com/github/sbt/git/GitPlugin.scala
+++ b/src/main/scala/com/github/sbt/git/GitPlugin.scala
@@ -135,6 +135,40 @@ object SbtGit {
     ThisBuild / gitUncommittedChanges := gitReader.value.withGit(_.hasUncommittedChanges),
     scmInfo := parseScmInfo(gitReader.value.withGit(_.remoteOrigin))
   )
+
+  /** Settings that are added to the `Global` scope by [[GitPlugin]].
+   *
+   * sbt's `lintUnused` check reports settings that no other setting or task consumes. Most of the keys
+   * this plugin defines are exactly that: they are read by the `git` command, by the user's release
+   * process, or only when git versioning is enabled, so sbt cannot see a consumer for them and warns
+   * about the settings this plugin itself contributed. Excluding them keeps builds warning free out of
+   * the box. See https://github.com/sbt/sbt-git/issues/379
+   */
+  def globalSettings: Seq[Setting[?]] = Seq(
+    Global / excludeLintKeys ++= Set[Def.KeyedInitialize[?]](
+      baseVersion,
+      formattedDateVersion,
+      formattedShaVersion,
+      gitBranch,
+      gitCurrentBranch,
+      gitCurrentTags,
+      gitDescribePatterns,
+      gitDescribedVersion,
+      gitHeadCommit,
+      gitHeadCommitDate,
+      gitHeadMessage,
+      gitReader,
+      gitRemoteRepo,
+      gitTagToVersionNumber,
+      gitUncommittedChanges,
+      scmInfo,
+      uncommittedSignifier,
+      useConsoleForROGit,
+      useGitDescribe,
+      versionProperty
+    )
+  )
+
   private[sbt] def parseScmInfo(remoteOrigin: String): Option[ScmInfo] = {
     val user = """(?:[^@\/]+@)?"""
     val domain = """([^\/]+)"""
@@ -351,6 +385,7 @@ object GitPlugin extends AutoPlugin {
     def useReadableConsoleGit = SbtGit.useReadableConsoleGit
     def showCurrentGitBranch = SbtGit.showCurrentGitBranch
   }
+  override def globalSettings: Seq[Setting[?]] = SbtGit.globalSettings
   override def buildSettings: Seq[Setting[?]] = SbtGit.buildSettings
   override def projectSettings: Seq[Setting[?]] = SbtGit.projectSettings
 }

--- a/src/sbt-test/lint/exclude-lint-keys/build.sbt
+++ b/src/sbt-test/lint/exclude-lint-keys/build.sbt
@@ -1,0 +1,42 @@
+enablePlugins(GitVersioning)
+
+// These keys are set, but nothing else in this build consumes them. sbt's `lintUnused` check
+// would report them (and the ones the plugin itself sets) unless sbt-git excludes its own keys.
+// See https://github.com/sbt/sbt-git/issues/379
+git.remoteRepo := "git@github.com:sbt/sbt-git.git"
+ThisBuild / git.baseVersion := "1.0"
+ThisBuild / git.useGitDescribe := true
+
+lazy val checkLintUnused = taskKey[Unit]("Checks that lintUnused does not report keys owned by sbt-git")
+
+checkLintUnused := {
+  val s = state.value
+  val extracted = Project.extract(s)
+  val include = extracted.get(Global / lintIncludeFilter)
+  val exclude = extracted.get(Global / lintExcludeFilter)
+  val reported = sbt.internal.LintUnused.lintUnused(s, include, exclude).map(_._1.key.label).toSet
+  val gitKeys = Set(
+    "baseVersion",
+    "formattedDateVersion",
+    "formattedShaVersion",
+    "gitBranch",
+    "gitCurrentBranch",
+    "gitCurrentTags",
+    "gitDescribePatterns",
+    "gitDescribedVersion",
+    "gitHeadCommit",
+    "gitHeadCommitDate",
+    "gitHeadMessage",
+    "gitReader",
+    "gitRemoteRepo",
+    "gitTagToVersionNumber",
+    "gitUncommittedChanges",
+    "scmInfo",
+    "uncommittedSignifier",
+    "useConsoleForROGit",
+    "useGitDescribe",
+    "versionProperty"
+  )
+  val unexpected = reported.intersect(gitKeys)
+  assert(unexpected.isEmpty, s"lintUnused reported sbt-git keys: ${unexpected.toSeq.sorted.mkString(", ")}")
+}

--- a/src/sbt-test/lint/exclude-lint-keys/project/plugins.sbt
+++ b/src/sbt-test/lint/exclude-lint-keys/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-git" % sys.props("project.version"))

--- a/src/sbt-test/lint/exclude-lint-keys/test
+++ b/src/sbt-test/lint/exclude-lint-keys/test
@@ -1,0 +1,7 @@
+> git init
+> git config user.email "test@jsuereth.com"
+> git config user.name "Tester"
+> git add build.sbt
+> git commit -m "test"
+> lintUnused
+> checkLintUnused


### PR DESCRIPTION
Fixes #379.

## Problem

`GitPlugin` sets a number of keys eagerly in `buildSettings`/`projectSettings` that a build only consumes when git versioning is enabled, or that are read by commands rather than by other settings. sbt's `lintUnused` check cannot see that, so it reports them as unused and points at `GitPlugin.scala`:

```
[warn] * ThisBuild / gitUncommittedChanges
[warn] * ThisBuild / scmInfo
[warn] * root / gitDescribedVersion
```

Worth noting why this only shows up for some builds: `LintUnused` only reports a candidate whose recorded position passes `isLocallyDefined`, i.e. some position's `path` contains a `/`. The released `sbt-git 2.1.0` sbt-2 artifact recorded positions whose "path" is the setting's *source text* (`ThisBuild / gitUncommittedChanges := …`), which contains a `/` and therefore passes; a rebuild of the same source with sbt 2.0.0 today records `LinePosition(GitPlugin.scala, 135)` and the keys silently pass instead. So the warnings can appear and disappear across releases, and the fix should not depend on that.

## Fix

Add `globalSettings` that appends the keys this plugin owns to `Global / excludeLintKeys`. The exclusion matches on key label, so it is independent of the scope a key ends up in and of the positions baked into the published plugin.

`excludeLintKeys` is preferred over `withRank(KeyRanks.Invisible)`, which would also hide these user-facing keys from `settings`/`inspect`.

The list also covers `gitRemoteRepo` and `gitBranch`, which nothing in the plugin ever reads, so users who set them were being warned at too. `scmInfo` is included because the plugin is what sets it in `buildSettings` — that is the second warning in the issue.

## Test

New scripted test `src/sbt-test/lint/exclude-lint-keys` sets git keys that nothing in the build consumes and asserts `LintUnused.lintUnused` reports none of the plugin's keys. Without the plugin change it fails with `lintUnused reported sbt-git keys: gitRemoteRepo`.

## Verification

- Reproduced the issue on sbt 2.0.0 with sbt-ci-release 1.12.1 and released sbt-git 2.1.0: the exact warnings for `ThisBuild / gitUncommittedChanges` and `root / gitDescribedVersion`; adding those labels to `excludeLintKeys` turns the run into `[success] ok`.
- Locally published before/after builds in a scratch project: unfixed reports `[baseVersion, useGitDescribe, gitRemoteRepo]`, fixed reports `[]` — on sbt 2.0.0 and on sbt 1.x, confirming plugin `globalSettings` are applied after sbt's own `excludeLintKeys := …` in both.
- `+compile`, `++3.x test`, `scalafmtCheckAll` / `scalafmtSbtCheck`, and `++3.x scripted lint/exclude-lint-keys` pass locally. The sbt 1.x scripted suite could not be run locally (sbt 1.5.8 ships Scala 2.12.14, which fails with `bad constant pool index` on JDK 21/26 — pre-existing, existing tests fail identically), so CI covers that side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)